### PR TITLE
unify keyboards

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -63,7 +63,7 @@ map /  <Plug>(incsearch-forward)
 map ?  <Plug>(incsearch-backward)
 
 " share clipborad
-set clipboard=unnamed
+set clipboard=unnamedplus
 
 set nobackup
 set nowritebackup

--- a/tmux.conf.linux
+++ b/tmux.conf.linux
@@ -4,7 +4,7 @@ unbind C-l
 set-option -g prefix M-u
 
 bind-key -t vi-copy 'v' begin-selection
-bind-key -t vi-copy 'y' copy-pipe 'xclip -in -selection primary'
+bind-key -t vi-copy 'y' copy-pipe 'xclip -in -selection clipboard'
 
 set -g default-terminal "screen-256color"
 


### PR DESCRIPTION
X11 has several kinds of clipboards.

- Primary: the one that is used when you copy with mouse drag, paste with the middle button
- Clipboard: the "MS-stlyle"

Since Primary doesn't provide keyboard shortcuts, sticking with the Clipboard throughout tmux and vim is more consistent.